### PR TITLE
Issue #14

### DIFF
--- a/src/FluentValidation.Validators.UnitTestExtension.Tests/Composer/Core/AbstractValidatorExtensionTest.cs
+++ b/src/FluentValidation.Validators.UnitTestExtension.Tests/Composer/Core/AbstractValidatorExtensionTest.cs
@@ -2,7 +2,9 @@
 {
 	using FluentAssertions;
 	using Helpers;
+	using UnitTestExtension.Composer;
 	using UnitTestExtension.Core;
+	using ValidatorVerifiers;
 	using Xunit;
 	using Xunit.Sdk;
 
@@ -111,10 +113,37 @@
 			AssertExtension.NotThrows(() => customerValidator.ShouldHaveRules(x => x.Email, new FakeValidatorVerifier()));
 		}
 
+		[Fact]
+		public void
+			Given_ValidatorWhichIsValidatingProperty_When_ValidatingModelWithSimilarNullableFields_Then_ValidationPass()
+		{
+			// Arrange
+			var modelWithNullableFieldsValidator = new ModelWithNullableFieldsValidator();
+
+			// Act & assert
+			AssertExtension.NotThrows(() => modelWithNullableFieldsValidator.ShouldHaveRules(x => x.NullableInt.Value,
+                new ComparisonValidatorVerifier<GreaterThanValidator>(0)));
+		}
+
 		private class FakeValidator<T> : AbstractValidator<T>
 		{
 		}
 
+		private class ModelWithNullableFields
+		{
+			public int? NullableInt { get; set; }
+			public int? AnotherNullableInt { get; set; }
+		}
+
+		private class ModelWithNullableFieldsValidator : AbstractValidator<ModelWithNullableFields>
+		{
+			public ModelWithNullableFieldsValidator()
+			{
+				this.RuleFor(model => model.NullableInt.Value).GreaterThan(0);
+				this.RuleFor(model => model.AnotherNullableInt.Value).GreaterThan(0);
+			}
+		}
+		
 		private class Customer
 		{
 			public string Name { get; set; }

--- a/src/FluentValidation.Validators.UnitTestExtension/Core/AbstractValidatorExtension.cs
+++ b/src/FluentValidation.Validators.UnitTestExtension/Core/AbstractValidatorExtension.cs
@@ -5,7 +5,9 @@
     using System.Linq;
     using System.Linq.Expressions;
     using FluentAssertions;
+    using FluentValidation.Internal;
     using Internal;
+    using Internal.Extensions;
 
     public static class AbstractValidatorExtension
     {
@@ -25,7 +27,7 @@
 
             var validators = new List<IPropertyValidator>();
 
-            validator.Select(x => (PropertyRule)x).Where(r => r.Member == expression.GetMember()).SelectMany(x => x.Validators).ToList().ForEach(
+            validator.Select(x => (PropertyRule)x).Where(r => r.Expression.CompareMembersRecursively(expression)).SelectMany(x => x.Validators).ToList().ForEach(
                 propertyValidator =>
                 {
                     if (propertyValidator is IDelegatingValidator delegatingValidator)

--- a/src/FluentValidation.Validators.UnitTestExtension/Internal/Extensions/ExpressionComparisonExtensions.cs
+++ b/src/FluentValidation.Validators.UnitTestExtension/Internal/Extensions/ExpressionComparisonExtensions.cs
@@ -1,0 +1,38 @@
+namespace FluentValidation.Validators.UnitTestExtension.Internal.Extensions
+{
+    using System.Linq.Expressions;
+
+    internal static class ExpressionComparisonExtensions
+    {
+        /// <summary>
+        /// Compares members of two expressions recursively.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <param name="otherExpression"></param>
+        /// <returns> Whether the two expressions are equal in terms of their members.</returns>
+        public static bool CompareMembersRecursively(this Expression expression, Expression otherExpression)
+        {
+            if (expression.NodeType == otherExpression.NodeType)
+            {
+                switch (expression.NodeType)
+                {
+                    case ExpressionType.Parameter:
+                        return true;
+                    case ExpressionType.Lambda:
+                        return CompareMembersRecursively(((LambdaExpression) expression).Body,
+                            ((LambdaExpression) otherExpression).Body);
+                    case ExpressionType.MemberAccess:
+                        var memberExpression = expression as MemberExpression;
+                        var otherMemberExpression = otherExpression as MemberExpression;
+
+                        return memberExpression != null && otherMemberExpression != null &&
+                               memberExpression.Member == otherMemberExpression.Member &&
+                               CompareMembersRecursively(memberExpression.Expression, otherMemberExpression.Expression);
+                }
+            }
+
+            return false;
+        }
+        
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/MichalJankowskii/FluentValidation.Validators.UnitTestExtension/issues/14

The issue was particularly prevalent when working with nullable types as most of the time validator rules have `.Value` at the end. Something like this:
``` C#
RuleFor(x => x.NullableInt.Value)
	.GreaterThan(0)
		.When(x => x.NullableInt.HasValue);

RuleFor(x => x.OtherNullableInt.Value)
	.GreaterThan(0)
		.When(x => x.OtherNullableInt.HasValue);

```

The problem was that `ShouldHaveRules` method only considers the immediate `Member`s of all the rules. However, this doesn't work when one tries to do something like this: 
``` C#
RuleFor(x => x.Driver.Id)
	.GreaterThan(0)
		.When(x => x.Driver != null);

RuleFor(x => x.Assistant.Id)
	.GreaterThan(0)
		.When(x => x.Assistant != null);
```
As then only `Id` part gets considered and it seems like `x.Driver.Id` and `x.Assistant.Id` are the same thing as they have the same names and same types.

To fix this I propose to recursively compare the expressions. This way we go all the way down and we can then notice that actually the `Driver` and `Assistant` parts are different types with different names.